### PR TITLE
Implements jerk control for joystick

### DIFF
--- a/include/StepperControl.h
+++ b/include/StepperControl.h
@@ -9,6 +9,7 @@ void changeDirection();
 void dryRun();
 void homeRail();
 void joyStick();
+int speedControl(long loopNr);
 void stallDetection();
 bool stepMotor(int stepDirection, unsigned long stepperDelay);
 void toggleStepper(bool enable);

--- a/include/VariableDeclarations.h
+++ b/include/VariableDeclarations.h
@@ -60,9 +60,12 @@ extern MCUFRIEND_kbv 	  tft;
 // microsteps and positions
 #define nrMicrosteps			4						  // number of microsteps per full step
 #define microstepDistance 1.25          // distance travelled per microstep
-#define railTravel        73            // 75mm travel minus 1.5mm for bushing/washer
+#define railLength        150           // total length of actuator rails
+#define stageLength       75            // total length of rail stage
+#define bushingOverhang   1.9           // screw bushing protrudes and prevents stage from fully reaching rear end
+#define railTravel        73.1          // 150mm rail length minus 75mm stage length minus 1.9mm for bushing overhang
 #define minPosition       0
-#define maxPosition       58400         // 1mm pitch x 4 microsteps/step x 200 steps/revoluton * 73mm
+#define maxPosition       58480         // 1mm pitch x 4 microsteps/step x 200 steps/revoluton * 73mm
                                         // but consistently getting 58780 after homing
 // joystick defs
 #define xStickUpper			  515 				  // upper limit of joystick values that determines when to move stepper
@@ -151,6 +154,7 @@ extern bool shutterEnabled;
 extern bool targetFlag;
 extern bool flashReady;
 extern bool stallGuardConfigured;
+extern bool autoStackMax;
 // --- Position values --- //
 extern long startPosition;
 extern long prevStartPosition;

--- a/src/DriverConfig.cpp
+++ b/src/DriverConfig.cpp
@@ -17,7 +17,7 @@ void stallGuardConfig() {
   driver.sg_min(1); // if sg_result < sg_min*32, current increase
   driver.sg_max(3); // if sg_result >= (sg_min+sg_max+1)*32, current decrease
   driver.sedn(0b01);
-  driver.sg_stall_value(0);
+  driver.sg_stall_value(-5);
   driver.stealthChop(0);
 }
 

--- a/src/DriverConfig.cpp
+++ b/src/DriverConfig.cpp
@@ -4,6 +4,7 @@
 void stallGuardConfig() {
   stallGuardConfigured = true;
   //set TMC2130 config
+  stepper.setAcceleration(1000);
   driver.push(); // reset registers
   driver.toff(3);
   driver.tbl(1);
@@ -23,6 +24,7 @@ void stallGuardConfig() {
 
 // config for TMC2130 when running all other functions as stealthChop is preferred
 void silentStepConfig() {
+  stepper.setAcceleration(2000);
   stallGuardConfigured = false;
   driver.push(); // reset registers
   driver.stealthChop(1);

--- a/src/MiscFunctions.cpp
+++ b/src/MiscFunctions.cpp
@@ -23,7 +23,7 @@ void estimateDuration(bool screenRefresh) {
     tft.fillRect(x, y, w, h, CUSTOM_BLUE);
     tft.setCursor(15, 140);
     tft.println(timeMinutesSeconds);
-    
+
     prevMinutes = minutes;
     prevSeconds = seconds;
     // assign new time to prev variable
@@ -91,7 +91,7 @@ void setStepDistance() {
 }
 
 void setAutoStackPositions(bool setStart, bool setEnd) {
-  if (setStart == 1) {
+  if (setStart == true) {
     // lower limit
     if (startPosition < 0) {
       startPosition = 0;
@@ -110,9 +110,14 @@ void setAutoStackPositions(bool setStart, bool setEnd) {
     goToStart = true;
   }
 
-  if (setEnd == 1) {
-    // get new value
-    endPosition = stepper.currentPosition();
+  if (setEnd == true) {
+    // set new end value
+    if (autoStackMax == true) {
+      endPosition = maxPosition;
+    }
+    else if (autoStackMax == false) {
+      endPosition = stepper.currentPosition();
+    }
     // print end point if changed
     if (prevEndPosition != endPosition && activeScreen == 4) {
       int16_t x1, y1;
@@ -121,6 +126,7 @@ void setAutoStackPositions(bool setStart, bool setEnd) {
       tft.getTextBounds(String(prevEndPosition), 35, 145, &x1, &y1, &w, &h);
       tft.fillRect(x1, y1, w, h, BLACK);
       updateValueField("End Position", WHITE);
+      prevEndPosition = endPosition;
     }
   }
 

--- a/src/MiscFunctions.cpp
+++ b/src/MiscFunctions.cpp
@@ -23,9 +23,7 @@ void estimateDuration(bool screenRefresh) {
     tft.fillRect(x, y, w, h, CUSTOM_BLUE);
     tft.setCursor(15, 140);
     tft.println(timeMinutesSeconds);
-    Serial.print("Time: ");
-    Serial.println(timeMinutesSeconds);
-
+    
     prevMinutes = minutes;
     prevSeconds = seconds;
     // assign new time to prev variable

--- a/src/StepperControl.cpp
+++ b/src/StepperControl.cpp
@@ -85,6 +85,8 @@ void changeDirection() {
     directionFwd = true;
   }
   stepper.moveTo(moveDist);
+  Serial.print("Current Pos: ");
+  Serial.println(stepper.currentPosition());
 }
 
 void dryRun() {
@@ -131,7 +133,6 @@ void homeRail() {
 	if (stallGuardConfigured == false) {
 		stallGuardConfig();
 	}
-
   // reset positions
   fwdPosition = 0;
   bwdPosition = 0;
@@ -159,6 +160,7 @@ void homeRail() {
 	}
   homedRail = true;
   firstFwdStall = true; // reset first stall check in case homeRail run again
+  firstBwdStall = true;
   // config silentStep after homing
   silentStepConfig();
 }
@@ -231,7 +233,6 @@ void stallDetection() {
     }
     if (directionFwd == true && firstFwdStall == true) {
       fwdPosition = stepper.currentPosition();
-      firstFwdStall = false;
     }
     toggleStepper(1);
     changeDirection();

--- a/src/StepperControl.cpp
+++ b/src/StepperControl.cpp
@@ -33,16 +33,16 @@ void autoStack() {
 		stepperMoved = false;
 		shutterTriggered = false;
     prevStepTime = millis();
-    Serial.println("0. Start");
+    // Serial.println("0. Start");
   }
   // take photo and increment progress for first step of each movement
   if (completedMovements <= movementsRequired && stepperMoved == false) {
 		// if shutter enabled, take photo
 		if (shutterEnabled == true && shutterTriggered == false) {
-      Serial.println("1. Ready");
+      // Serial.println("1. Ready");
 	    shutterTriggered = triggerShutter(); // take photo
       if (shutterTriggered == true){
-        Serial.println("2. Photo Taken");
+        // Serial.println("2. Photo Taken");
       }
 		}
 
@@ -50,7 +50,7 @@ void autoStack() {
 		stepperMoved = stepMotor(1, shutterDelay*1000); // forward direction, shutterdelay
 
 		if (stepperMoved == true) {
-      Serial.println("3. Step Taken");
+      // Serial.println("3. Step Taken");
 			completedMovements++;
 	    // make sure correct screen is displaying
 	    if (activeScreen == 3) { // auto screen
@@ -85,8 +85,8 @@ void changeDirection() {
     directionFwd = true;
   }
   stepper.moveTo(moveDist);
-  Serial.print("Current Pos: ");
-  Serial.println(stepper.currentPosition());
+  // Serial.print("Current Pos: ");
+  // Serial.println(stepper.currentPosition());
 }
 
 void dryRun() {
@@ -147,6 +147,11 @@ void homeRail() {
 	// after stall, change direction and run to 50000 or stall
 	while (bwdPosition != 0 || fwdPosition <= 9999) {
 		stepper.run();
+    // int sg_result = driver.sg_result();
+    // if (sg_result <= 50) {
+    //   Serial.print("SG Result: ");
+    //   Serial.println(sg_result);
+    // }
 	}
 	// if back and forward position set, move to middle position
 	if (bwdPosition == 0 && fwdPosition > 10000) {
@@ -160,7 +165,6 @@ void homeRail() {
 	}
   homedRail = true;
   firstFwdStall = true; // reset first stall check in case homeRail run again
-  firstBwdStall = true;
   // config silentStep after homing
   silentStepConfig();
 }
@@ -205,13 +209,13 @@ void joyStick() {
     if (prevStartPosition != startPosition) {
       prevStartPosition = startPosition;
     }
-    setAutoStackPositions(1, 0); //set start but not end position
+    setAutoStackPositions(true, false); //set start but not end position
   }
   if (editEndPosition == true && arrowsActive == true) {
     if (prevEndPosition != endPosition) {
       prevEndPosition = endPosition;
     }
-    setAutoStackPositions(0, 1); //set end but not start position
+    setAutoStackPositions(false, true); //set end but not start position
   }
   if (activeScreen == 2 || activeScreen == 4) {
     displayPosition();

--- a/src/TouchControl.cpp
+++ b/src/TouchControl.cpp
@@ -29,6 +29,7 @@ int arrowsTouch(TSPoint &point, bool moveStepper, int val = 0) {
   return val;
 }
 
+
 void autoConfigScreenTouch(TSPoint &point) {
   // scale from 0->1023 to tft dimension and swap coordinates
   int xPos = map(point.y, TS_MINY, TS_MAXY, 0, tft.width());
@@ -52,14 +53,15 @@ void autoConfigScreenTouch(TSPoint &point) {
       prevGenericTime = millis();
     }
   }
-  // set start position
+  // set start position using arrows or joystick
   if (editStartPosition == true && arrowsActive == true) {
     if (prevStartPosition != startPosition) {
       prevStartPosition = startPosition;
     }
     int val = arrowsTouch(point, 1, 0);
-    setAutoStackPositions(1, 0); //set start but not end position
+    setAutoStackPositions(true, false); //set start but not end position
   }
+
   // end button
   if ((xPos >= 10 && xPos <= 120) && (yPos >= 90 && yPos <= 160) && (editShutterDelay + editStartPosition) == 0) {
     if ((currentTime - prevGenericTime) >= genericTouchDelay) {
@@ -78,15 +80,16 @@ void autoConfigScreenTouch(TSPoint &point) {
       prevGenericTime = millis();
     }
   }
-  // set end position
+  // set end position using arrows or joystick
   if (editEndPosition == true && arrowsActive == true) {
     if (prevEndPosition != endPosition) {
       prevEndPosition = endPosition;
     }
 
     int val = arrowsTouch(point, 1, 0);
-    setAutoStackPositions(0, 1); //set end but not start position
+    setAutoStackPositions(false, true); //set end but not start position
   }
+  
   // run button
   if ((xPos >= 10 && xPos <= 120) && (yPos >= 170 && yPos <= 240) && (editShutterDelay + editStartPosition + editEndPosition) == 0) {
     tft.fillRoundRect(10, 184, 5, 35, 4, YELLOW);
@@ -124,6 +127,7 @@ void autoConfigScreenTouch(TSPoint &point) {
     autoScreen();
   }
 }
+
 
 void autoScreenTouch(TSPoint &point) {
   // scale from 0->1023 to tft dimension and swap coordinates
@@ -195,6 +199,7 @@ void autoScreenTouch(TSPoint &point) {
     startScreen();
   }
 }
+
 
 void flashScreenTouch(TSPoint &point) {
   // scale from 0->1023 to tft dimension and swap coordinates
@@ -276,6 +281,7 @@ void flashScreenTouch(TSPoint &point) {
   }
 }
 
+
 void manualScreenTouch(TSPoint &point) {
   // scale from 0->1023 to tft dimension and swap coordinates
   int xPos = map(point.y, TS_MINY, TS_MAXY, 0, tft.width());
@@ -349,6 +355,7 @@ void manualScreenTouch(TSPoint &point) {
   }
 }
 
+
 void startScreenTouch(TSPoint &point) {
   // scale from 0->1023 to tft dimension and swap coordinates
   int xPos = map(point.y, TS_MINY, TS_MAXY, 0, tft.width());
@@ -378,6 +385,7 @@ void startScreenTouch(TSPoint &point) {
     resetAutoStack(); // reset autostack settings
   }
 }
+
 
 void touchScreen() {
   currentTime = millis(); // call frequently just in case

--- a/src/TouchControl.cpp
+++ b/src/TouchControl.cpp
@@ -365,6 +365,7 @@ void startScreenTouch(TSPoint &point) {
   // homing func
   if ((xPos >= 20 && xPos <= 100) && (yPos >= 190 && yPos <= 240)) {
     tft.drawBitmap(30, 190, house, 50, 42, CUSTOM_RED);
+    bootFlag = true;
     homeRail();
     tft.drawBitmap(30, 190, house, 50, 42, WHITE);
   }

--- a/src/UserInterface.cpp
+++ b/src/UserInterface.cpp
@@ -2,6 +2,14 @@
 #include "UserInterface.h"
 #include "ShutterControl.h"
 
+
+/***********************************************************************
+autoConfig screen of the controller. Allows user to:
+  - Set START point for autoStack procedure
+  - Set END point for autoStack procedure
+  - Do a fast dry run of the procedure with current START/END points
+  - Move stepper forwards/backwards one step at a time
+***********************************************************************/
 void autoConfigScreen() {
   activeScreen = 4;
   tft.fillScreen(BLACK);
@@ -45,6 +53,16 @@ void autoConfigScreen() {
   drawArrows();
 }
 
+
+/***********************************************************************
+Auto screen of the controller. Allows user to:
+  - Set step distance for stepper
+  - See estimated time remaining for an AutoStack sequence
+  - See autoStack procedure progress as "completed / remaining"
+  - Start/Stop/Pause autoStack procedure
+  - Enable/disable shutter trigger
+  - Open autoStack configuration
+***********************************************************************/
 void autoScreen() {
   activeScreen = 3;
   tft.fillScreen(BLACK);
@@ -94,6 +112,11 @@ void autoScreen() {
   }
 }
 
+
+/***********************************************************************
+Updates the current position on the screen depending on whether the
+current screen is the Manual or autoConfig screen.
+***********************************************************************/
 void displayPosition() {
   // update for new values
   if (prevStepperPosition != stepper.currentPosition()) {
@@ -129,6 +152,10 @@ void displayPosition() {
   }
 }
 
+
+/***********************************************************************
+Draws the Up/Down arrows in the Manual and AutoConfig screens
+***********************************************************************/
 void drawArrows() {
   tft.fillTriangle(230, 65, 260, 15, 290, 65, CUSTOM_GREEN);
   tft.fillRoundRect(245, 69, 30, 36, 4, CUSTOM_GREEN);
@@ -137,6 +164,10 @@ void drawArrows() {
   tft.fillRoundRect(245, 135, 30, 36, 4, CUSTOM_RED);
 }
 
+
+/***********************************************************************
+Draws the Play/Pause buttons in the AutoStack screen of the controller
+***********************************************************************/
 void drawPlayPause(bool greyPlay = 0, bool greyPause = 0) {
   if (greyPlay == 1) {
     tft.fillCircle(270, 75, 37, CUSTOM_GREY_LITE);
@@ -157,6 +188,14 @@ void drawPlayPause(bool greyPlay = 0, bool greyPause = 0) {
   }
 }
 
+
+/***********************************************************************
+Flash screen of the controller. Allows user to:
+  - Set ON value for expected light sensor reading when flash is ready
+  - Set OFF value for expected light sensor reading when flash is recycling
+  - Calculate new trigger threshold
+  - Test the flash is currently working with given threshold
+***********************************************************************/
 void flashScreen() {
   activeScreen = 5;
   flashReady = flashStatus(); // get latest value
@@ -204,6 +243,14 @@ void flashScreen() {
   tft.drawBitmap(135, 175, backArrow, 50, 50, WHITE);
 }
 
+
+/***********************************************************************
+Manual screen of the controller. Allows user to:
+  - Set step distance for stepper (distance travelled per step)
+  - View current position of stepper in mm
+  - Enable/disable shutter trigger
+  - Move stepper forward/back one step by specified step distance
+***********************************************************************/
 void manualScreen() {
   activeScreen = 2;
   tft.fillScreen(BLACK);
@@ -249,6 +296,15 @@ void manualScreen() {
   drawArrows();
 }
 
+
+/***********************************************************************
+Main screen of the controller. Allows user to:
+  - Home Rail
+  - Calibrate flash trigger point
+  - Clear the current autoStack sequence
+  - Move the stepper in Manual mode
+  - Create and run an AutoStack procedure
+***********************************************************************/
 void startScreen() {
   activeScreen = 1;
   tft.fillScreen(BLACK);
@@ -283,6 +339,12 @@ void startScreen() {
   }
 }
 
+
+/***********************************************************************
+Updates the screen with light sensor readings of the Flash LED. Used
+to calibrate optimal trigger point for flash given lighting conditions
+at the time that may affect the light sensor.
+***********************************************************************/
 void updateFlashValue() {
   // get latest flashValue reading
   flashReady = flashStatus();
@@ -300,6 +362,12 @@ void updateFlashValue() {
   }
 }
 
+
+/***********************************************************************
+Updates the autoStack screen with current progress of stack sequence.
+Uses sprintf_P function to concatenate two values and format them as
+"completed / remaining" on the screen.
+***********************************************************************/
 void updateProgress(bool screenRefresh) {
   char autoStackProgress[10]      = "0/0";
 
@@ -322,6 +390,7 @@ void updateProgress(bool screenRefresh) {
     sprintf_P(prevAutoStackProgress, PSTR("%02d:%02d"), completedMovements, movementsRequired);
   }
 }
+
 
 /***********************************************************************
 Generic function for updating various values in different fields.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,7 +115,6 @@ int prevCompletedMovements 				= 1;   				// used for overwriting prev movement 
 char prevAutoStackProgress[10]  	= "0/0";			// prev progress value, global to prevent overwriting each loop
 bool stepperMoved 								= false; 			// did stepMotor actually step or not
 bool shutterTriggered 						= false;			// did the shutter trigger or not
-
 // ***** --- PROGRAM --- ***** //
 
 void setup(void) {
@@ -215,7 +214,7 @@ void loop() {
   }
   // run homing sequence if first loop
   if (bootFlag == true) {
-    // homeRail();
+    homeRail();
 		setAutoStackPositions(1, 1);
 		silentStepConfig(); // set config for silentStep
     bootFlag = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,7 @@
 // ----- DEFINITIONS ----- //
 // STEP 				= one microstep step of the stepper stepper motor
 // MOVEMENT 		= one full movement of linear rail by specified distance, consisting of multiple steps
-// PROECDURE 		= one completed stack procedure, consisting of multiple movements
+// PROCEDURE 		= one completed stack procedure, consisting of multiple movements
 // DISTANCE 		= distance travelled per movement = number of steps per movement * 0.0025mm
 // MANUAL MODE 	= user input required to step motor by specified distance
 // AUTOSTACK 		= automatic mode, stepper completes procedure without further input
@@ -89,6 +89,7 @@ bool shutterEnabled 								= false;      // disabled/enabled
 bool targetFlag 									= false;      // resets stepper target
 bool flashReady 									= false;			// flash ready for next photo
 bool stallGuardConfigured 				= true;				// stallGuard config has run
+bool autoStackMax                 = false;      // set endPosition to max for indetermine autoStack procedure
 // --- Position values --- //
 long startPosition 								= 0;        	// start position for stack procedure
 long prevStartPosition 						= 0;
@@ -154,7 +155,7 @@ void setup(void) {
 
   // set stepper AccelStepper config
   stepper.setMaxSpeed(3200);
-  stepper.setAcceleration(2000);
+  // stepper.setAcceleration(2000);
   stepper.setEnablePin(EN_PIN);
   stepper.setPinsInverted(false, false, true);
   stepper.enableOutputs();
@@ -203,6 +204,12 @@ void loop() {
 		if (activeScreen == 5 && (editFlashOffValue == true || editFlashOnValue == true)) {
 			updateFlashValue();
 		}
+    // set END as maxPosition if Z Stick depressed
+    if (activeScreen == 4 && editEndPosition == true && digitalRead(ZSTICK_PIN) == LOW) {
+      autoStackMax = true;
+      setAutoStackPositions(false, true);
+      autoStackMax = false;
+    }
 
     subRoutine2Time = millis();
   }
@@ -215,7 +222,7 @@ void loop() {
   // run homing sequence if first loop
   if (bootFlag == true) {
     homeRail();
-		setAutoStackPositions(1, 1);
+		setAutoStackPositions(true, true);
 		silentStepConfig(); // set config for silentStep
     bootFlag = false;
   }


### PR DESCRIPTION
Prevents the rail from jerking when using joystick and accelerating from 0 to max speed in a short amount of time. speedControl() function modifiers the stepperSpeed value for the first 5,000 loops of the joystick while() function, decreasing speed by a factor of loopNr / 5000. This results in a smooth, but still fast, ramp up in speed that minimises jerk almost completely.